### PR TITLE
Update dependencies, including chokidar to v3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
-  - '0.12'
-  - '0.10'
+  - '12'
+  - '10'
+  - '8'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# grunt-chokidar v1.0.1 [![Build Status: Linux](https://travis-ci.org/JimmyRobz/grunt-chokidar.png?branch=master)](https://travis-ci.org/JimmyRobz/grunt-chokidar)
+# grunt-chokidar v1.0.1 [![Build Status: Linux](https://travis-ci.org/JimmyRobz/grunt-chokidar.svg?branch=master)](https://travis-ci.org/JimmyRobz/grunt-chokidar)
 
 > Run predefined tasks whenever watched file patterns are added, changed or deleted using [chokidar](http://github.com/paulmillr/chokidar).
 
 
 
 ## Getting Started
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `>=1.0.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 

--- a/package.json
+++ b/package.json
@@ -21,28 +21,27 @@
     }
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "chokidar": "^2.0.4",
-    "lodash": "^4.7.11",
+    "async": "^3.0.1",
+    "chokidar": "^3.0.1",
+    "lodash": "^4.17.11",
     "tiny-lr": "^1.1.1"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-internal": "^0.4.7",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt-jscs": "^1.0.0",
-    "underscore.string": "^2.3.3"
+    "grunt": "^1.0.4",
+    "grunt-contrib-internal": "^3.1.0",
+    "grunt-contrib-jshint": "^2.1.0",
+    "grunt-contrib-nodeunit": "^2.0.0",
+    "grunt-jscs": "^3.0.1",
+    "underscore.string": "^3.3.5"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=1.0.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
 
   LR.prototype.trigger = function(files) {
     grunt.log.verbose.writeln('Live reloading ' + grunt.log.wordlist(files) + '...');
-    this.server.changed({body:{files:files}});
+    this.server.changed({body: {files: files}});
   };
 
   return function(options) {

--- a/test/tasks/helper.js
+++ b/test/tasks/helper.js
@@ -40,7 +40,7 @@ helper.assertTask = function assertTask(task, options) {
   // Return an interface for testing this task
   function returnFunc(runs, done) {
     // Spawn the node this process uses
-    var spawnGrunt = spawn(process.argv[0], spawnOptions, {cwd:cwd});
+    var spawnGrunt = spawn(process.argv[0], spawnOptions, {cwd: cwd});
     var out = '';
 
     if (!Array.isArray(runs)) {

--- a/test/tasks/nospawn_test.js
+++ b/test/tasks/nospawn_test.js
@@ -29,7 +29,7 @@ exports.nospawn = {
   nospawn: function(test) {
     test.expect(3);
     var cwd = path.resolve(fixtures, 'nospawn');
-    var assertWatch = helper.assertTask(['server', 'chokidar'], {cwd:cwd});
+    var assertWatch = helper.assertTask(['server', 'chokidar'], {cwd: cwd});
     assertWatch(function() {
       var write = 'var nospawn = true;';
       grunt.file.write(path.join(cwd, 'lib', 'nospawn.js'), write);
@@ -45,15 +45,13 @@ exports.nospawn = {
   interrupt: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'nospawn');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch([function() {
       var write = 'var interrupt = true;';
       grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), write);
       setTimeout(function() {
         grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), write);
       }, 1000);
-    }, function() {
-      // Two functions needed to run two rounds of watching
     }], function(result) {
       helper.verboseLog(result);
       var count = result.match((new RegExp('Running "long" task', 'g'))).length;

--- a/test/tasks/patterns_test.js
+++ b/test/tasks/patterns_test.js
@@ -26,7 +26,7 @@ exports.patterns = {
   negate: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'patterns');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'sub', 'dontedit.js'), 'var dontedit = true;');
       setTimeout(function() {

--- a/test/tasks/reloadgruntfile_test.js
+++ b/test/tasks/reloadgruntfile_test.js
@@ -32,7 +32,7 @@ exports.reloadgruntfile = {
   reloadgruntfile: function(test) {
     test.expect(3);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch([function() {
       // First edit a file and trigger the watch
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');

--- a/test/tasks/watch_test.js
+++ b/test/tasks/watch_test.js
@@ -30,9 +30,9 @@ exports.watch = {
   atBegin: function(test) {
     test.expect(1);
     var cwd = path.resolve(fixtures, 'atBegin');
-    var assertWatch = helper.assertTask(['chokidar', '--debug'], {cwd:cwd});
+    var assertWatch = helper.assertTask(['chokidar', '--debug'], {cwd: cwd});
     assertWatch(function() {
-       // noop. Does not modify any watched files.
+      // noop. Does not modify any watched files.
     }, function(result) {
       helper.verboseLog(result);
       var firstIndex = result.indexOf('one has changed');
@@ -43,7 +43,7 @@ exports.watch = {
   dateFormat: function(test) {
     test.expect(1);
     var cwd = path.resolve(fixtures, 'dateFormat');
-    var assertWatch = helper.assertTask(['chokidar', '--debug'], {cwd:cwd});
+    var assertWatch = helper.assertTask(['chokidar', '--debug'], {cwd: cwd});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');
     }, function(result) {
@@ -55,7 +55,7 @@ exports.watch = {
   oneTarget: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'oneTarget');
-    var assertWatch = helper.assertTask(['chokidar', '--debug'], {cwd:cwd});
+    var assertWatch = helper.assertTask(['chokidar', '--debug'], {cwd: cwd});
     assertWatch(function() {
       var write = 'var test = true;';
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), write);
@@ -70,7 +70,7 @@ exports.watch = {
   multiTargetsTriggerOneNotTwo: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch(function() {
       var write = 'var test = true;';
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), write);
@@ -84,7 +84,7 @@ exports.watch = {
   multiTargetsSequentialFilesChangeTriggerBoth: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch([function() {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var test = true;');
     }, function() {
@@ -99,7 +99,7 @@ exports.watch = {
   multiTargetsSimultaneousFilesChangeTriggerBoth: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch([function() {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var test = true;');
       grunt.file.write(path.join(cwd, 'lib', 'two.js'), 'var test = true;');
@@ -113,7 +113,7 @@ exports.watch = {
   spawnOneAtATime: function(test) {
     test.expect(1);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'wait.js'), 'var wait = false;');
       setTimeout(function() {
@@ -128,7 +128,7 @@ exports.watch = {
   interrupt: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), 'var interrupt = 1;');
       setTimeout(function() {
@@ -150,7 +150,7 @@ exports.watch = {
   failingTask: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar', {cwd: cwd});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'fail.js'), 'var fail = false;');
     }, function(result) {
@@ -163,7 +163,7 @@ exports.watch = {
   cwd: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
-    var assertWatch = helper.assertTask('chokidar:cwd', {cwd:cwd});
+    var assertWatch = helper.assertTask('chokidar:cwd', {cwd: cwd});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var test = true;');
     }, function(result) {


### PR DESCRIPTION
From the [chokidar v3 changelog](https://github.com/paulmillr/chokidar/releases/tag/3.0.0):

> Massive CPU & RAM consumption improvements. 17x package & deps size reduction. Node 8+-only

Due to "Node 8+-only", Travis config and package.json "engines" have been updated accordingly.

Also had to fix some formatting due to updating `grunt-jscs`.